### PR TITLE
fix Name json was shadowed.

### DIFF
--- a/src/Data/Codec/Argonaut.purs
+++ b/src/Data/Codec/Argonaut.purs
@@ -257,5 +257,5 @@ fix f =
 prismaticCodec ∷ ∀ a b. (a → Maybe b) → (b → a) → JsonCodec a → JsonCodec b
 prismaticCodec f g orig =
   basicCodec
-    (\json → note (UnexpectedValue json) <<< f =<< (decode orig json))
+    (\json' → note (UnexpectedValue json') <<< f =<< (decode orig json'))
     (encode orig <<< g)


### PR DESCRIPTION
I got: `Name json was shadowed. in value declaration prismaticCodec` when building project this should fix it