### PR TITLE
Document the `Data.Codec.Argonaut.Migration` module

### DIFF
--- a/src/Data/Codec/Argonaut/Migration.purs
+++ b/src/Data/Codec/Argonaut/Migration.purs
@@ -1,3 +1,12 @@
+-- | Codecs that provide forward migrations. In a forward migration, the decoder
+-- | migrates to the new format while decoding from JSON and the encoder uses
+-- | the new format while encoding to JSON.
+-- |
+-- | If you need more control over a forward migration, the `Functor` instance
+-- | allows operating on the underlying `Json` value directly.
+-- |
+-- | If you need both forward and backward migrations, the `Profunctor` instance
+-- | allows operating on the underlying `Json` value directly in both directions.
 module Data.Codec.Argonaut.Migration
   ( addDefaultField
   , updateField


### PR DESCRIPTION
We discussed on Slack about documenting the motivation behind the `Data.Codec.Argonaut.Migration` module. Here's what I realized while discussing yesterday:
* The module is concerned with forward migrations of JSON objects.
* Forward migrations can be implemented with the `Functor` instance for `Data.Codec.GCodec _ _ _`.
* Backward and forward migrations can be implemented with the `Profunctor` instance for `Data.Codec.GCodec _ _`.

I tried to capture those realizations. Let me know if there's different wording or if I missed the mark. More than happy to make any changes.