### PR TITLE
Update Usage example to be less confusing to newer PureScript developers

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,24 @@ import Data.Argonaut.Core as J
 import Data.Codec.Argonaut as CA
 import Data.Either (Either)
 
-encodeString ∷ String → J.Json
-encodeString = CA.encode CA.string
+codec = CA.array CA.string
 
-decodeString ∷ J.Json → Either CA.JsonDecodeError String
-decodeString = CA.decode CA.string
+encodeStringArray ∷ Array String → J.Json
+encodeStringArray = CA.encode codec
+
+decodeStringArray ∷ J.Json → Either CA.JsonDecodeError (Array String)
+decodeStringArray = CA.decode codec
+```
+
+To parse a serialized `String` into a `J.Json` structure use the [`Parser.jsonParser`](https://pursuit.purescript.org/packages/purescript-argonaut-core/5.1.0/docs/Data.Argonaut.Parser).
+
+To /"stringify"/ (serialize) your `Array String` to a serialized JSON `String` we would use the [`stringify`](https://pursuit.purescript.org/packages/purescript-argonaut-core/5.1.0/docs/Data.Argonaut.Core#v:stringify) like so:
+
+``` purescript
+import Control.Category ((>>>))
+
+serialize :: Array String -> String
+serialize = encodeStringArray >>> J.stringify
 ```
 
 ### Basic codecs


### PR DESCRIPTION
Last week there was confusion with a TypeScript developer I am on-boarding to PureScript because they didn't know how to serialize and deserialize from the `Json` parse tree.

Sources of confusion:
- the example of decoding/encoding a Json `String` confused developer since they thought the `encodeString :: String -> Json` was the way to deserialize, so I changed the example to decoding/encoding an `Array String` instead.
- since there was a gap in determining the correct way to serialize and deserialize I provided pointers in the *Usage* section.

Feel free to reject if you don't think this is the level of the target audience using `codec-argonaut`.

Thanks for the library, it has an elegant design. It is just needing some explaining to the developers new to PureScript that I am on-boarding now. I can always just keep this in our own knowledge base too. Thanks.