### PR TITLE
Update for PureScript 0.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ bower install purescript-codec-argonaut
 
 As [`JsonCodec`](https://pursuit.purescript.org/packages/purescript-codec-argonaut/docs/Data.Codec.Argonaut#t:JsonCodec)s are values, they need to be fed into the [`encode`](https://pursuit.purescript.org/packages/purescript-codec/docs/Data.Codec/#v:encode) or [`decode`](https://pursuit.purescript.org/packages/purescript-codec/docs/Data.Codec/#v:decode) function provided by [`Data.Codec`](https://pursuit.purescript.org/packages/purescript-codec/docs/Data.Codec) (and re-exported by [`Data.Codec.Argonaut`](https://pursuit.purescript.org/packages/purescript-codec-argonaut/docs/Data.Codec.Argonaut)):
 
-``` purescript
+```purescript
 import Data.Argonaut.Core as J
 import Data.Codec.Argonaut as CA
 import Data.Either (Either)
@@ -39,7 +39,7 @@ To parse a serialized `String` into a `J.Json` structure use the [`Parser.jsonPa
 
 To /"stringify"/ (serialize) your `Array String` to a serialized JSON `String` we would use the [`stringify`](https://pursuit.purescript.org/packages/purescript-argonaut-core/5.1.0/docs/Data.Argonaut.Core#v:stringify) like so:
 
-``` purescript
+```purescript
 import Control.Category ((>>>))
 
 serialize :: Array String -> String
@@ -60,7 +60,7 @@ So far so boring. Things only start getting interesting or useful when we can bu
 
 The simplest compound codec provided by the library is [`CA.array`](https://pursuit.purescript.org/packages/purescript-codec-argonaut/docs/Data.Codec.Argonaut#v:array), which accepts another codec, and encodes/decodes an arbitrary length array where all the items match the inner codec. For example:
 
-``` purescript
+```purescript
 import Data.Codec.Argonaut as CA
 
 codec ∷ CA.JsonCodec (Array String)
@@ -71,7 +71,7 @@ codec = CA.array CA.string
 
 Probably the most useful compound codec is for `Record`, this will generally be the building block of most codecs. There are a few different ways to define these codecs, but the most convenient is the [`record`](https://pursuit.purescript.org/packages/purescript-codec-argonaut/docs/Data.Codec.Argonaut.Record#v:record) function provided by [`Data.Codec.Argonaut.Record`](https://pursuit.purescript.org/packages/purescript-codec-argonaut/docs/Data.Codec.Argonaut.Record):
 
-``` purescript
+```purescript
 import Data.Codec.Argonaut as CA
 import Data.Codec.Argonaut.Record as CAR
 
@@ -91,13 +91,13 @@ Note we also used a [`CA.object`](https://pursuit.purescript.org/packages/puresc
 
 The codec will encode/decode JSON objects of the same shape as the defining record. For example:
 
-``` json
+```json
 { "name": "Rashida", "age": 37, "active": true }
 ```
 
 It's possible to encode/decode records that include properties with spaces and/or symbols in the name, or reserved names, by quoting the fields in the type and definition:
 
-``` purescript
+```purescript
 type Person = { "Name" ∷ String, age ∷ Int, "is active" ∷ Boolean }
 
 codec ∷ CA.JsonCodec Person
@@ -116,7 +116,7 @@ This library comes with codec support for [`purescript-variant`](https://github.
 
 First of all, variants. Similar to the object/record case there are a few options for defining variant codecs, but most commonly they will be defined with [`variantMatch`](https://pursuit.purescript.org/packages/purescript-codec-argonaut/docs/Data.Codec.Argonaut.Variant#v:variantMatch) provided by [`Data.Codec.Argonaut.Variant`](https://pursuit.purescript.org/packages/purescript-codec-argonaut/docs/Data.Codec.Argonaut.Variant):
 
-``` purescript
+```purescript
 import Prelude
 
 import Data.Codec.Argonaut as CA
@@ -142,7 +142,7 @@ The fields in the record passed to [`CAV.variantMatch`](https://pursuit.purescri
 
 The variant codec is a little opinionated since there's no exactly corresponding JSON structure for sums. The encoding looks something like:
 
-``` json
+```json
 { "tag": <constructorName>, "value": <value> }
 ```
 
@@ -150,15 +150,15 @@ The variant codec is a little opinionated since there's no exactly corresponding
 
 Sum type encoding is usually handled by building a variant codec, and then using [`dimap`](https://pursuit.purescript.org/packages/purescript-profunctor/docs/Data.Profunctor#v:dimap) to inject into/project out of a corresponding sum type:
 
-``` purescript
+```purescript
 import Prelude
 
 import Data.Codec.Argonaut as CA
 import Data.Codec.Argonaut.Variant as CAV
 import Data.Either (Either(..))
 import Data.Profunctor (dimap)
-import Data.Symbol (SProxy(..))
 import Data.Variant as V
+import Type.Proxy (Proxy(..))
 
 data SomeValue2 = Str String | Int Int | Neither
 
@@ -171,9 +171,9 @@ codec =
     }
   where
     toVariant = case _ of
-      Str s → V.inj (SProxy ∷ _ "str") s
-      Int i → V.inj (SProxy ∷ _ "int") i
-      Neither → V.inj (SProxy ∷ _ "neither") unit
+      Str s → V.inj (Proxy ∷ _ "str") s
+      Int i → V.inj (Proxy ∷ _ "int") i
+      Neither → V.inj (Proxy ∷ _ "neither") unit
     fromVariant = V.match
       { str: Str
       , int: Int
@@ -181,7 +181,7 @@ codec =
       }
 ```
 
-This certainly is a little boilerplate-y, but at least when defining codecs this way you do gain the benefits of having a single definition that aligns the encoding and decoding behaviour. This means, assuming there are no mixups in  `toVariant`/`fromVariant`, the guaranteed roundtripping is preserved. Often it's not even possible to have mixups during `dimap`, since the sum constructor types will all differ.
+This certainly is a little boilerplate-y, but at least when defining codecs this way you do gain the benefits of having a single definition that aligns the encoding and decoding behaviour. This means, assuming there are no mixups in `toVariant`/`fromVariant`, the guaranteed roundtripping is preserved. Often it's not even possible to have mixups during `dimap`, since the sum constructor types will all differ.
 
 If you have a sum type that only consists of nullary constructors and it has a [`Generic`](https://pursuit.purescript.org/packages/purescript-generics-rep/docs/Data.Generic.Rep#t:Generic) instance defined, [`nullarySum`](https://pursuit.purescript.org/packages/purescript-codec-argonaut/docs/Data.Codec.Argonaut.Generic#v:nullarySum) provided by [`Data.Codec.Argonaut.Generic`](https://pursuit.purescript.org/packages/purescript-codec-argonaut/docs/Data.Codec.Argonaut.Generic) can generate a codec that will encode the constructors as string values matching the constructor names in the JSON.
 
@@ -197,7 +197,7 @@ There is also a [`Data.Codec.Argonaut.Compat`](https://pursuit.purescript.org/pa
 
 If you have a codec for a `newtype` with a [`Newtype`](https://pursuit.purescript.org/packages/purescript-newtype/docs/Data.Newtype#t:Newtype) instance, you can use the [`wrapIso`](https://pursuit.purescript.org/packages/purescript-profunctor/docs/Data.Profunctor#v:wrapIso) function from [`purescript-profunctor`](https://github.com/purescript/purescript-profunctor) to adapt a codec to work with the `newtype`. For example:
 
-``` purescript
+```purescript
 import Data.Codec.Argonaut.Common as CA
 import Data.Codec.Argonaut.Record as CAR
 import Data.Newtype (class Newtype)
@@ -225,7 +225,7 @@ If you have a type with a pair of functions like the `preview` and `view` that m
 
 For example, to adapt the [`CA.string`](https://pursuit.purescript.org/packages/purescript-codec-argonaut/docs/Data.Codec.Argonaut#v:string) codec to only work for `NonEmptyString`s:
 
-``` purescript
+```purescript
 import Data.Codec.Argonaut as CA
 import Data.String.NonEmpty (NonEmptyString)
 import Data.String.NonEmpty as NES

--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,7 @@
   ],
   "dependencies": {
     "purescript-argonaut-core": "^6.0.0",
-    "purescript-codec": "thomashoneyman/purescript-codec#master",
+    "purescript-codec": "^4.0.0",
     "purescript-variant": "^7.0.1",
     "purescript-ordered-collections": "^2.0.0",
     "purescript-type-equality": "^4.0.0"

--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git://github.com/garyb/purescript-codec-argonaut.git"
+    "url": "https://github.com/garyb/purescript-codec-argonaut.git"
   },
   "ignore": [
     "**/.*",
@@ -16,15 +16,14 @@
     "package.json"
   ],
   "dependencies": {
-    "purescript-argonaut-core": "^5.0.0",
-    "purescript-codec": "v3.0.0",
-    "purescript-generics-rep": "^6.0.0",
-    "purescript-variant": "^6.0.0",
-    "purescript-ordered-collections": "^1.0.0",
-    "purescript-type-equality": "^3.0.0"
+    "purescript-argonaut-core": "^6.0.0",
+    "purescript-codec": "thomashoneyman/purescript-codec#master",
+    "purescript-variant": "^7.0.1",
+    "purescript-ordered-collections": "^2.0.0",
+    "purescript-type-equality": "^4.0.0"
   },
   "devDependencies": {
-    "purescript-argonaut-codecs": "^6.0.0",
-    "purescript-quickcheck": "^6.1.0"
+    "purescript-argonaut-codecs": "^8.0.0",
+    "purescript-quickcheck": "^7.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
     "test": "pulp test"
   },
   "devDependencies": {
-    "pulp": "^13.0.0",
-    "purescript": "^0.13.0",
-    "purescript-psa": "^0.7.3",
-    "rimraf": "^2.6.2"
+    "pulp": "^15.0.0",
+    "purescript": "^0.14.0",
+    "purescript-psa": "^0.8.2",
+    "rimraf": "^3.0.0"
   }
 }

--- a/src/Data/Codec/Argonaut.purs
+++ b/src/Data/Codec/Argonaut.purs
@@ -45,7 +45,7 @@ import Data.Maybe (Maybe(..), maybe, fromJust)
 import Data.Profunctor.Star (Star(..))
 import Data.String as S
 import Data.String.CodeUnits as SCU
-import Data.Symbol (class IsSymbol, SProxy, reflectSymbol)
+import Data.Symbol (class IsSymbol, reflectSymbol)
 import Data.Traversable (traverse)
 import Data.Tuple (Tuple(..))
 import Foreign.Object as FO
@@ -234,15 +234,15 @@ prop key codec = GCodec dec enc
 -- | `{ "name": "Karl", "age": 25 }` we would define a codec like this:
 -- | ```
 -- | import Data.Codec.Argonaut as CA
--- | import Data.Symbol (SProxy(..))
+-- | import Type.Proxy (Proxy(..))
 -- |
 -- | type Person = { name ∷ String, age ∷ Int }
 -- |
 -- | codecPerson ∷ CA.JsonCodec Person
 -- | codecPerson =
 -- |   CA.object "Person" $ CA.record
--- |     # CA.recordProp (SProxy :: _ "name") CA.string
--- |     # CA.recordProp (SProxy :: _ "age") CA.int
+-- |     # CA.recordProp (Proxy :: _ "name") CA.string
+-- |     # CA.recordProp (Proxy :: _ "age") CA.int
 -- | ```
 -- |
 -- | See also `Data.Codec.Argonaut.Record.object` for a more commonly useful
@@ -253,10 +253,10 @@ record = GCodec (pure {}) (Star \val → writer (Tuple val L.Nil))
 -- | Used with `record` to define codecs for record types that encode into JSON
 -- | objects of the same shape. See the comment on `record` for an example.
 recordProp
-  ∷ ∀ p a r r'
+  ∷ ∀ proxy p a r r'
   . IsSymbol p
   ⇒ Row.Cons p a r r'
-  ⇒ SProxy p
+  ⇒ proxy p
   → JsonCodec a
   → JPropCodec (Record r)
   → JPropCodec (Record r')

--- a/src/Data/Codec/Argonaut/Generic.purs
+++ b/src/Data/Codec/Argonaut/Generic.purs
@@ -8,7 +8,8 @@ import Data.Codec as C
 import Data.Codec.Argonaut as CA
 import Data.Either (Either(..), note)
 import Data.Generic.Rep (class Generic, Constructor(..), NoArguments(..), Sum(..), from, to)
-import Data.Symbol (class IsSymbol, SProxy(..), reflectSymbol)
+import Data.Symbol (class IsSymbol, reflectSymbol)
+import Type.Proxy (Proxy(..))
 
 -- | Encodes nullary sums with a Generic instance as strings that match the constructor names.
 -- |
@@ -41,9 +42,9 @@ instance nullarySumCodecSum ∷ (NullarySumCodec a, NullarySumCodec b) ⇒ Nulla
 
 instance nullarySumCodecCtor ∷ IsSymbol name ⇒ NullarySumCodec (Constructor name NoArguments) where
   nullarySumEncode _ =
-    J.fromString $ reflectSymbol (SProxy ∷ SProxy name)
+    J.fromString $ reflectSymbol (Proxy ∷ Proxy name)
   nullarySumDecode name j = do
     tag ← note (CA.Named name (CA.TypeMismatch "String")) (J.toString j)
-    if tag /= reflectSymbol (SProxy ∷ SProxy name)
+    if tag /= reflectSymbol (Proxy ∷ Proxy name)
       then Left (CA.Named name (CA.UnexpectedValue j))
       else Right (Constructor NoArguments)

--- a/src/Data/Codec/Argonaut/Record.purs
+++ b/src/Data/Codec/Argonaut/Record.purs
@@ -1,12 +1,12 @@
 module Data.Codec.Argonaut.Record where
 
 import Data.Codec.Argonaut as CA
-import Data.Symbol (class IsSymbol, SProxy(..))
+import Data.Symbol (class IsSymbol)
 import Prim.Row as R
 import Prim.RowList as RL
 import Record as Rec
-import Type.Data.RowList (RLProxy(..))
 import Type.Equality as TE
+import Type.Proxy (Proxy(..))
 import Unsafe.Coerce (unsafeCoerce)
 
 -- | Constructs a `JsonCodec` for a `Record` from a name and a record of codecs.
@@ -36,12 +36,12 @@ record
   ⇒ RowListCodec rl ri ro
   ⇒ Record ri
   → CA.JPropCodec (Record ro)
-record = rowListCodec (RLProxy ∷ RLProxy rl)
+record = rowListCodec (Proxy ∷ Proxy rl)
 
 -- | The class used to enable the building of `Record` codecs by providing a
 -- | record of codecs.
-class RowListCodec (rl ∷ RL.RowList) (ri ∷ # Type) (ro ∷ # Type) | rl → ri ro where
-  rowListCodec ∷ RLProxy rl → Record ri → CA.JPropCodec (Record ro)
+class RowListCodec (rl ∷ RL.RowList Type) (ri ∷ Row Type) (ro ∷ Row Type) | rl → ri ro where
+  rowListCodec ∷ forall proxy. proxy rl → Record ri → CA.JPropCodec (Record ro)
 
 instance rowListCodecNil ∷ RowListCodec RL.Nil () () where
   rowListCodec _ _ = CA.record
@@ -54,10 +54,10 @@ instance rowListCodecCons ∷
   , TE.TypeEquals co (CA.JsonCodec a)
   ) ⇒ RowListCodec (RL.Cons sym co rs) ri ro where
   rowListCodec _ codecs =
-    CA.recordProp (SProxy ∷ SProxy sym) codec tail
+    CA.recordProp (Proxy ∷ Proxy sym) codec tail
     where
     codec ∷ CA.JsonCodec a
-    codec = TE.from (Rec.get (SProxy ∷ SProxy sym) codecs)
+    codec = TE.from (Rec.get (Proxy ∷ Proxy sym) codecs)
 
     tail ∷ CA.JPropCodec (Record ro')
-    tail = rowListCodec (RLProxy ∷ RLProxy rs) ((unsafeCoerce ∷ Record ri → Record ri') codecs)
+    tail = rowListCodec (Proxy ∷ Proxy rs) ((unsafeCoerce ∷ Record ri → Record ri') codecs)

--- a/test/Test/Generic.purs
+++ b/test/Test/Generic.purs
@@ -4,7 +4,7 @@ import Prelude
 
 import Data.Codec.Argonaut.Generic (nullarySum)
 import Data.Generic.Rep (class Generic)
-import Data.Generic.Rep.Show (genericShow)
+import Data.Show.Generic (genericShow)
 import Effect (Effect)
 import Effect.Console (log)
 import Test.QuickCheck (quickCheck)

--- a/test/Test/Prim.purs
+++ b/test/Test/Prim.purs
@@ -10,18 +10,18 @@ import Data.Char.Gen (genAsciiChar)
 import Data.Codec.Argonaut.Common ((~))
 import Data.Codec.Argonaut.Common as JA
 import Data.Generic.Rep (class Generic)
-import Data.Generic.Rep.Show (genericShow)
 import Data.Maybe (Maybe(..))
 import Data.Newtype (class Newtype, unwrap, wrap)
 import Data.Profunctor (dimap)
+import Data.Show.Generic (genericShow)
 import Data.String.Gen (genAsciiString)
-import Data.Symbol (SProxy(..))
 import Effect (Effect)
 import Effect.Console (log)
 import Foreign.Object.Gen (genForeignObject)
 import Test.QuickCheck (Result, quickCheck)
 import Test.QuickCheck.Gen (Gen)
 import Test.Util (genInt, propCodec, propCodec', propCodec'')
+import Type.Proxy (Proxy(..))
 
 main :: Effect Unit
 main = do
@@ -102,9 +102,9 @@ codecObject =
 codecRecord ∷ JA.JsonCodec TestRecord
 codecRecord =
   JA.object "Test Record" $ JA.record
-    # JA.recordProp (SProxy ∷ SProxy "tag") JA.string
-    # JA.recordProp (SProxy ∷ SProxy "x") JA.int
-    # JA.recordProp (SProxy ∷ SProxy "y") JA.boolean
+    # JA.recordProp (Proxy ∷ Proxy "tag") JA.string
+    # JA.recordProp (Proxy ∷ Proxy "x") JA.int
+    # JA.recordProp (Proxy ∷ Proxy "y") JA.boolean
 
 propTestRecord ∷ JA.JsonCodec TestRecord → Gen Result
 propTestRecord = propCodec' checkEq print genRecord

--- a/test/Test/Variant.purs
+++ b/test/Test/Variant.purs
@@ -10,13 +10,13 @@ import Data.Either (Either(..))
 import Data.Maybe (Maybe(..))
 import Data.Profunctor (dimap)
 import Data.String.Gen (genAsciiString)
-import Data.Symbol (SProxy(..))
 import Data.Variant as V
 import Effect (Effect)
 import Effect.Console (log)
 import Test.QuickCheck (quickCheck)
 import Test.QuickCheck.Gen (Gen)
 import Test.Util (genInt, propCodec)
+import Type.Proxy (Proxy(..))
 
 type TestVariant = V.Variant
   ( a ∷ Int
@@ -60,8 +60,8 @@ codecMaybe codecA =
   fromVariant = V.case_
     # V.on _Just Just
     # V.on _Nothing (const Nothing)
-  _Just = SProxy ∷ SProxy "just"
-  _Nothing = SProxy ∷ SProxy "nothing"
+  _Just = Proxy ∷ Proxy "just"
+  _Nothing = Proxy ∷ Proxy "nothing"
 
 codecMaybeMatch ∷ ∀ a. JA.JsonCodec a → JA.JsonCodec (Maybe a)
 codecMaybeMatch codecA =
@@ -72,8 +72,8 @@ codecMaybeMatch codecA =
       })
   where
   toVariant = case _ of
-    Just a → V.inj (SProxy ∷ _ "just") a
-    Nothing → V.inj (SProxy ∷ _ "nothing") unit
+    Just a → V.inj (Proxy ∷ _ "just") a
+    Nothing → V.inj (Proxy ∷ _ "nothing") unit
   fromVariant = V.match
     { just: Just
     , nothing: \_ → Nothing
@@ -92,16 +92,16 @@ codecEither codecA codecB =
   fromVariant = V.case_
     # V.on _Left Left
     # V.on _Right Right
-  _Left = SProxy ∷ SProxy "left"
-  _Right = SProxy ∷ SProxy "right"
+  _Left = Proxy ∷ Proxy "left"
+  _Right = Proxy ∷ Proxy "right"
 
 genVariant ∷ Gen TestVariant
 genVariant = do
   tag ← chooseInt 1 3
   case tag of
-    1 → V.inj (SProxy ∷ SProxy "a") <$> genInt
-    2 → V.inj (SProxy ∷ SProxy "b") <$> genAsciiString
-    _ → V.inj (SProxy ∷ SProxy "c") <$> GenC.genMaybe chooseBool
+    1 → V.inj (Proxy ∷ Proxy "a") <$> genInt
+    2 → V.inj (Proxy ∷ Proxy "b") <$> genAsciiString
+    _ → V.inj (Proxy ∷ Proxy "c") <$> GenC.genMaybe chooseBool
 
 codecVariant ∷ JA.JsonCodec TestVariant
 codecVariant = JAV.variantMatch


### PR DESCRIPTION
Hi @garyb! This PR updates `codec-argonaut` for PureScript 0.14.

1. It updates your dependencies to new major dependencies in your `bower.json` file. I'm temporarily pointing at my fork of `codec` until that 0.14 PR is merged, at which point it can be updated here, too.
2. It updates your `package.json` file to use the latest compiler, as well as a compatible Pulp version and `psa` version.
3. It updates your source and test code and the README for compatibility with PureScript 0.14.

As far as the code changes go:

1. The `generics-rep` library has been merged into prelude, and the instance for `Show` moved into `Data.Show.Generic`.
2. There's no longer a need for the various proxy types, so I've replaced them everywhere with `Proxy` if you're using one, and `forall proxy. proxy ...` when it's in a function or class (so folks downstream can continue using whatever proxy type).
3. `RowList` is now `RowList Type`, and `# Type` is now `Row Type`.

If this all looks good, then if / when the `codec` PR merges then this can be quickly updated and you could make a v8.0.0 release. I can then update the library in package sets for you.