### PR TITLE
Update for PureScript 0.15

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,14 +16,14 @@
     "package.json"
   ],
   "dependencies": {
-    "purescript-argonaut-core": "^6.0.0",
-    "purescript-codec": "^4.0.0",
-    "purescript-variant": "^7.0.1",
-    "purescript-ordered-collections": "^2.0.0",
+    "purescript-argonaut-core": "^7.0.0",
+    "purescript-codec": "https://github.com/thomashoneyman/purescript-codec.git#trh/purs-0.15",
+    "purescript-variant": "^8.0.0",
+    "purescript-ordered-collections": "^3.0.0",
     "purescript-type-equality": "^4.0.0"
   },
   "devDependencies": {
-    "purescript-argonaut-codecs": "^8.0.0",
-    "purescript-quickcheck": "^7.0.0"
+    "purescript-argonaut-codecs": "^9.0.0",
+    "purescript-quickcheck": "^8.0.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,7 @@
   ],
   "dependencies": {
     "purescript-argonaut-core": "^7.0.0",
-    "purescript-codec": "https://github.com/thomashoneyman/purescript-codec.git#trh/purs-0.15",
+    "purescript-codec": "^5.0.0",
     "purescript-variant": "^8.0.0",
     "purescript-ordered-collections": "^3.0.0",
     "purescript-type-equality": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
     "test": "pulp test"
   },
   "devDependencies": {
-    "pulp": "^15.0.0",
-    "purescript": "^0.14.0",
+    "pulp": "^16.0.0",
+    "purescript": "^0.15.0",
     "purescript-psa": "^0.8.2",
     "rimraf": "^3.0.0"
   }

--- a/src/Data/Codec/Argonaut.purs
+++ b/src/Data/Codec/Argonaut.purs
@@ -51,6 +51,7 @@ import Data.Tuple (Tuple(..))
 import Foreign.Object as FO
 import Partial.Unsafe (unsafePartial)
 import Prim.Row as Row
+import Type.Proxy (Proxy)
 import Unsafe.Coerce (unsafeCoerce)
 
 -- | Codec type for `Json` values.
@@ -253,10 +254,10 @@ record = GCodec (pure {}) (Star \val → writer (Tuple val L.Nil))
 -- | Used with `record` to define codecs for record types that encode into JSON
 -- | objects of the same shape. See the comment on `record` for an example.
 recordProp
-  ∷ ∀ proxy p a r r'
+  ∷ ∀ p a r r'
   . IsSymbol p
   ⇒ Row.Cons p a r r'
-  ⇒ proxy p
+  ⇒ Proxy p
   → JsonCodec a
   → JPropCodec (Record r)
   → JPropCodec (Record r')

--- a/src/Data/Codec/Argonaut/Variant.purs
+++ b/src/Data/Codec/Argonaut/Variant.purs
@@ -89,10 +89,10 @@ variant ∷ JsonCodec (Variant ())
 variant = GCodec (ReaderT (Left <<< UnexpectedValue)) (Star case_)
 
 variantCase
-  ∷ ∀ proxy l a r r'
+  ∷ ∀ l a r r'
   . IsSymbol l
   ⇒ R.Cons l a r r'
-  ⇒ proxy l
+  ⇒ Proxy l
   → Either a (JsonCodec a)
   → JsonCodec (Variant r)
   → JsonCodec (Variant r')


### PR DESCRIPTION
This upgrades the code and dependencies for PureScript 0.15. Note: this shouldn't be merged until https://github.com/garyb/purescript-codec/pull/10 is merged and there is a new release.