### PR TITLE
Add purs-tidy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
 
       - uses: actions/setup-node@v1
         with:
-          node-version: "12"
+          node-version: "14"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
 
       - uses: actions/setup-node@v1
         with:
-          node-version: "14"
+          node-version: "16"
 
       - name: Install dependencies
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /.*
 !/.gitignore
 !/.github
+!/.tidyrc.json
 /bower_components/
 /node_modules/
 /output/

--- a/.tidyrc.json
+++ b/.tidyrc.json
@@ -1,0 +1,10 @@
+{
+  "importSort": "ide",
+  "importWrap": "source",
+  "indent": 2,
+  "operatorsFile": null,
+  "ribbon": 1,
+  "typeArrowPlacement": "first",
+  "unicode": "always",
+  "width": null
+}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "pulp": "^16.0.0",
     "purescript": "^0.15.0",
     "purescript-psa": "^0.8.2",
+    "purs-tidy": "^0.0.2",
     "rimraf": "^3.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "pulp": "^16.0.0",
     "purescript": "^0.15.0",
     "purescript-psa": "^0.8.2",
-    "purs-tidy": "^0.0.2",
+    "purs-tidy": "^0.9.2",
     "rimraf": "^3.0.0"
   }
 }

--- a/src/Data/Codec/Argonaut.purs
+++ b/src/Data/Codec/Argonaut.purs
@@ -30,18 +30,18 @@ module Data.Codec.Argonaut
 import Prelude
 
 import Control.Monad.Reader (ReaderT(..), runReaderT)
-import Control.Monad.Writer (Writer, writer, mapWriter)
+import Control.Monad.Writer (Writer, mapWriter, writer)
 import Data.Argonaut.Core as J
 import Data.Array as A
 import Data.Bifunctor as BF
 import Data.Codec (BasicCodec, Codec, GCodec(..), basicCodec, bihoistGCodec, decode, encode)
-import Data.Codec (decode, encode, (~), (<~<), (>~>)) as Exports
+import Data.Codec (decode, encode, (<~<), (>~>), (~)) as Exports
 import Data.Either (Either(..), note)
 import Data.Generic.Rep (class Generic)
 import Data.Int as I
 import Data.List ((:))
 import Data.List as L
-import Data.Maybe (Maybe(..), maybe, fromJust)
+import Data.Maybe (Maybe(..), fromJust, maybe)
 import Data.Profunctor.Star (Star(..))
 import Data.String as S
 import Data.String.CodeUnits as SCU
@@ -72,25 +72,25 @@ derive instance genericJsonDecodeError ∷ Generic JsonDecodeError _
 
 instance showJsonDecodeError ∷ Show JsonDecodeError where
   show = case _ of
-    TypeMismatch s -> "(TypeMismatch " <> show s <> ")"
-    UnexpectedValue j -> "(UnexpectedValue " <> J.stringify j <> ")"
-    AtIndex i e -> "(AtIndex " <> show i <> " " <> show e <> ")"
-    AtKey k e -> "(AtKey " <> show k <> " " <> show e <> ")"
-    Named s e -> "(Named " <> show s <> " " <> show e <> ")"
-    MissingValue -> "MissingValue"
+    TypeMismatch s → "(TypeMismatch " <> show s <> ")"
+    UnexpectedValue j → "(UnexpectedValue " <> J.stringify j <> ")"
+    AtIndex i e → "(AtIndex " <> show i <> " " <> show e <> ")"
+    AtKey k e → "(AtKey " <> show k <> " " <> show e <> ")"
+    Named s e → "(Named " <> show s <> " " <> show e <> ")"
+    MissingValue → "MissingValue"
 
 -- | Prints a `JsonDecodeError` as a somewhat readable error message.
 printJsonDecodeError ∷ JsonDecodeError → String
 printJsonDecodeError err =
   "An error occurred while decoding a JSON value:\n" <> go err
   where
-    go = case _ of
-      TypeMismatch ty → "  Expected value of type '" <> ty <> "'."
-      UnexpectedValue val → "  Unexpected value " <> J.stringify val <> "."
-      AtIndex ix inner → "  At array index " <> show ix <> ":\n" <> go inner
-      AtKey key inner → "  At object key " <> key <> ":\n" <> go inner
-      Named name inner → "  Under '" <> name <> "':\n" <> go inner
-      MissingValue → "  No value was found."
+  go = case _ of
+    TypeMismatch ty → "  Expected value of type '" <> ty <> "'."
+    UnexpectedValue val → "  Unexpected value " <> J.stringify val <> "."
+    AtIndex ix inner → "  At array index " <> show ix <> ":\n" <> go inner
+    AtKey key inner → "  At object key " <> key <> ":\n" <> go inner
+    Named name inner → "  Under '" <> name <> "':\n" <> go inner
+    MissingValue → "  No value was found."
 
 -- | The "identity codec" for `Json` values.
 json ∷ JsonCodec J.Json
@@ -162,7 +162,8 @@ type JIndexedCodec a =
     (Either JsonDecodeError)
     (Array J.Json)
     (L.List J.Json)
-    a a
+    a
+    a
 
 -- | A codec for types that are encoded as an array with a specific layout.
 -- |
@@ -203,7 +204,8 @@ type JPropCodec a =
     (Either JsonDecodeError)
     (FO.Object J.Json)
     (L.List (Tuple String J.Json))
-    a a
+    a
+    a
 
 -- | A codec for objects that are encoded with specific properties.
 -- |
@@ -224,6 +226,7 @@ prop key codec = GCodec dec enc
     BF.lmap (AtKey key) case FO.lookup key obj of
       Just val → decode codec val
       Nothing → Left MissingValue
+
   enc ∷ Star (Writer (L.List (Tuple String J.Json))) a a
   enc = Star \val → writer $ Tuple val (pure (Tuple key (encode codec val)))
 
@@ -264,28 +267,32 @@ recordProp
 recordProp p codecA codecR =
   let key = reflectSymbol p in GCodec (dec' key) (enc' key)
   where
-    dec' ∷ String → ReaderT (FO.Object J.Json) (Either JsonDecodeError) (Record r')
-    dec' key = ReaderT \obj → do
-      r ← decode codecR obj
-      a ← BF.lmap (AtKey key) case FO.lookup key obj of
-        Just val → decode codecA val
-        Nothing → Left MissingValue
-      pure $ unsafeSet key a r
-    enc' ∷ String → Star (Writer (L.List (Tuple String J.Json))) (Record r') (Record r')
-    enc' key = Star \val →
-      writer $ Tuple val
-        $ Tuple key (encode codecA (unsafeGet key val))
-        : encode codecR (unsafeForget val)
-    unsafeForget ∷ Record r' → Record r
-    unsafeForget = unsafeCoerce
-    unsafeSet ∷ String → a → Record r → Record r'
-    unsafeSet key a = unsafeCoerce <<< FO.insert key a <<< unsafeCoerce
-    unsafeGet ∷ String → Record r' → a
-    unsafeGet s = unsafePartial fromJust <<< FO.lookup s <<< unsafeCoerce
+  dec' ∷ String → ReaderT (FO.Object J.Json) (Either JsonDecodeError) (Record r')
+  dec' key = ReaderT \obj → do
+    r ← decode codecR obj
+    a ← BF.lmap (AtKey key) case FO.lookup key obj of
+      Just val → decode codecA val
+      Nothing → Left MissingValue
+    pure $ unsafeSet key a r
+
+  enc' ∷ String → Star (Writer (L.List (Tuple String J.Json))) (Record r') (Record r')
+  enc' key = Star \val →
+    writer $ Tuple val
+      $ Tuple key (encode codecA (unsafeGet key val))
+          : encode codecR (unsafeForget val)
+
+  unsafeForget ∷ Record r' → Record r
+  unsafeForget = unsafeCoerce
+
+  unsafeSet ∷ String → a → Record r → Record r'
+  unsafeSet key a = unsafeCoerce <<< FO.insert key a <<< unsafeCoerce
+
+  unsafeGet ∷ String → Record r' → a
+  unsafeGet s = unsafePartial fromJust <<< FO.lookup s <<< unsafeCoerce
 
 jsonPrimCodec
   ∷ ∀ a
-   . String
+  . String
   → (J.Json → Maybe a)
   → (a → J.Json)
   → JsonCodec a

--- a/src/Data/Codec/Argonaut/Common.purs
+++ b/src/Data/Codec/Argonaut/Common.purs
@@ -14,8 +14,8 @@ import Data.List as L
 import Data.Map as M
 import Data.Maybe (Maybe(..))
 import Data.Profunctor (dimap)
-import Foreign.Object as FO
 import Data.Tuple (Tuple(..), fst, snd)
+import Foreign.Object as FO
 
 -- | A codec for `Maybe` values.
 -- |

--- a/src/Data/Codec/Argonaut/Compat.purs
+++ b/src/Data/Codec/Argonaut/Compat.purs
@@ -15,9 +15,9 @@ import Data.Codec.Argonaut.Common (either, list, map, tuple) as Common
 import Data.Either (Either)
 import Data.Functor as F
 import Data.Maybe (Maybe(..))
-import Foreign.Object as FO
 import Data.Traversable (traverse)
 import Data.Tuple (Tuple(..))
+import Foreign.Object as FO
 
 -- | A codec for `Maybe` values.
 -- |
@@ -32,6 +32,7 @@ maybe codec = basicCodec dec enc
   dec j
     | J.isNull j = pure Nothing
     | otherwise = BF.bimap (Named "Maybe") Just ((decode codec j))
+
   enc ∷ Maybe a → J.Json
   enc = case _ of
     Nothing → J.jsonNull
@@ -53,6 +54,7 @@ foreignObject codec =
   where
   fromArray ∷ ∀ v. Array (Tuple String v) → FO.Object v
   fromArray = FO.fromFoldable
+
   decodeItem ∷ Tuple String J.Json → Either JsonDecodeError (Tuple String a)
   decodeItem (Tuple key value) =
     BF.bimap (AtKey key) (Tuple key) (decode codec value)

--- a/src/Data/Codec/Argonaut/Generic.purs
+++ b/src/Data/Codec/Argonaut/Generic.purs
@@ -36,8 +36,7 @@ instance nullarySumCodecSum ∷ (NullarySumCodec a, NullarySumCodec b) ⇒ Nulla
   nullarySumEncode = case _ of
     Inl a → nullarySumEncode a
     Inr b → nullarySumEncode b
-  nullarySumDecode name j
-    = Inl <$> nullarySumDecode name j
+  nullarySumDecode name j = Inl <$> nullarySumDecode name j
     <|> Inr <$> nullarySumDecode name j
 
 instance nullarySumCodecCtor ∷ IsSymbol name ⇒ NullarySumCodec (Constructor name NoArguments) where
@@ -45,6 +44,5 @@ instance nullarySumCodecCtor ∷ IsSymbol name ⇒ NullarySumCodec (Constructor 
     J.fromString $ reflectSymbol (Proxy ∷ Proxy name)
   nullarySumDecode name j = do
     tag ← note (CA.Named name (CA.TypeMismatch "String")) (J.toString j)
-    if tag /= reflectSymbol (Proxy ∷ Proxy name)
-      then Left (CA.Named name (CA.UnexpectedValue j))
-      else Right (Constructor NoArguments)
+    if tag /= reflectSymbol (Proxy ∷ Proxy name) then Left (CA.Named name (CA.UnexpectedValue j))
+    else Right (Constructor NoArguments)

--- a/src/Data/Codec/Argonaut/Generic.purs
+++ b/src/Data/Codec/Argonaut/Generic.purs
@@ -44,5 +44,7 @@ instance nullarySumCodecCtor ∷ IsSymbol name ⇒ NullarySumCodec (Constructor 
     J.fromString $ reflectSymbol (Proxy ∷ Proxy name)
   nullarySumDecode name j = do
     tag ← note (CA.Named name (CA.TypeMismatch "String")) (J.toString j)
-    if tag /= reflectSymbol (Proxy ∷ Proxy name) then Left (CA.Named name (CA.UnexpectedValue j))
-    else Right (Constructor NoArguments)
+    if tag /= reflectSymbol (Proxy ∷ Proxy name) then 
+      Left (CA.Named name (CA.UnexpectedValue j))
+    else
+      Right (Constructor NoArguments)

--- a/src/Data/Codec/Argonaut/Record.purs
+++ b/src/Data/Codec/Argonaut/Record.purs
@@ -41,7 +41,7 @@ record = rowListCodec (Proxy ∷ Proxy rl)
 -- | The class used to enable the building of `Record` codecs by providing a
 -- | record of codecs.
 class RowListCodec (rl ∷ RL.RowList Type) (ri ∷ Row Type) (ro ∷ Row Type) | rl → ri ro where
-  rowListCodec ∷ forall proxy. proxy rl → Record ri → CA.JPropCodec (Record ro)
+  rowListCodec ∷ ∀ proxy. proxy rl → Record ri → CA.JPropCodec (Record ro)
 
 instance rowListCodecNil ∷ RowListCodec RL.Nil () () where
   rowListCodec _ _ = CA.record
@@ -52,7 +52,8 @@ instance rowListCodecCons ∷
   , R.Cons sym a ro' ro
   , IsSymbol sym
   , TE.TypeEquals co (CA.JsonCodec a)
-  ) ⇒ RowListCodec (RL.Cons sym co rs) ri ro where
+  ) ⇒
+  RowListCodec (RL.Cons sym co rs) ri ro where
   rowListCodec _ codecs =
     CA.recordProp (Proxy ∷ Proxy sym) codec tail
     where

--- a/src/Data/Codec/Argonaut/Sum.purs
+++ b/src/Data/Codec/Argonaut/Sum.purs
@@ -14,9 +14,9 @@ import Data.Codec.Argonaut (JsonCodec, JsonDecodeError(..), jobject, json, prop,
 import Data.Either (Either(..))
 import Data.Maybe (Maybe(..), maybe)
 import Data.Profunctor.Star (Star(..))
+import Data.Tuple (Tuple(..))
 import Foreign.Object as FO
 import Foreign.Object.ST as FOST
-import Data.Tuple (Tuple(..))
 
 -- | A helper for defining JSON codecs for "enum" sum types, where every
 -- | constructor is nullary, and the type will be encoded as a string.
@@ -33,6 +33,7 @@ enumSum printTag parseTag = GCodec dec enc
     case parseTag value of
       Just a → Right a
       Nothing → Left (UnexpectedValue j)
+
   enc ∷ Star (Writer J.Json) a a
   enc = Star \a → writer $ Tuple a (encode string (printTag a))
 
@@ -70,6 +71,7 @@ taggedSum name printTag parseTag f g = GCodec decodeCase encodeCase
           Right decoder → do
             value ← decode (prop "value" json) obj
             lmap (AtKey "value") (decoder value)
+
   encodeCase ∷ Star (Writer J.Json) a a
   encodeCase = Star case _ of
     a | Tuple tag value ← g a →
@@ -77,4 +79,4 @@ taggedSum name printTag parseTag f g = GCodec decodeCase encodeCase
         FO.runST do
           obj ← FOST.new
           _ ← FOST.poke "tag" (encode string (printTag tag)) obj
-          maybe (pure obj) (\v -> FOST.poke "value" v obj) value
+          maybe (pure obj) (\v → FOST.poke "value" v obj) value

--- a/src/Data/Codec/Argonaut/Variant.purs
+++ b/src/Data/Codec/Argonaut/Variant.purs
@@ -103,12 +103,14 @@ variantCase proxy eacodec (GCodec dec enc) = GCodec dec' enc'
   dec' = ReaderT \j → do
     obj ← decode jobject j
     tag ← decode (prop "tag" string) obj
-    if tag == reflectSymbol proxy then case eacodec of
-      Left a → pure (inj proxy a)
-      Right codec → do
-        value ← decode (prop "value" json) obj
-        inj proxy <$> decode codec value
-    else coerceR <$> runReaderT dec j
+    if tag == reflectSymbol proxy then 
+      case eacodec of
+        Left a → pure (inj proxy a)
+        Right codec → do
+          value ← decode (prop "value" json) obj
+          inj proxy <$> decode codec value
+    else
+      coerceR <$> runReaderT dec j
 
   enc' ∷ Star (Writer J.Json) (Variant r') (Variant r')
   enc' = Star \v →

--- a/src/Data/Codec/Argonaut/Variant.purs
+++ b/src/Data/Codec/Argonaut/Variant.purs
@@ -19,8 +19,8 @@ import Prim.Row as R
 import Prim.RowList as RL
 import Record as Rec
 import Type.Equality as TE
-import Unsafe.Coerce (unsafeCoerce)
 import Type.Proxy (Proxy(..))
+import Unsafe.Coerce (unsafeCoerce)
 
 -- | Builds a codec for a variant from a record, similar to the way
 -- | `Variant.match` works to pattern match on a variant.
@@ -103,25 +103,26 @@ variantCase proxy eacodec (GCodec dec enc) = GCodec dec' enc'
   dec' = ReaderT \j → do
     obj ← decode jobject j
     tag ← decode (prop "tag" string) obj
-    if tag == reflectSymbol proxy
-      then case eacodec of
-        Left a → pure (inj proxy a)
-        Right codec → do
-          value ← decode (prop "value" json) obj
-          inj proxy <$> decode codec value
-      else coerceR <$> runReaderT dec j
+    if tag == reflectSymbol proxy then case eacodec of
+      Left a → pure (inj proxy a)
+      Right codec → do
+        value ← decode (prop "value" json) obj
+        inj proxy <$> decode codec value
+    else coerceR <$> runReaderT dec j
 
   enc' ∷ Star (Writer J.Json) (Variant r') (Variant r')
   enc' = Star \v →
     on proxy
-      (\v' → writer $ Tuple v $ encode jobject $
-        FO.runST do
-          obj ← FOST.new
-          _ ← FOST.poke "tag" (encode string (reflectSymbol proxy)) obj
-          case eacodec of
-            Left _ → pure obj
-            Right codec → FOST.poke "value" (encode codec v') obj)
-      (\v' → un Star enc v' $> v) v
+      ( \v' → writer $ Tuple v $ encode jobject $
+          FO.runST do
+            obj ← FOST.new
+            _ ← FOST.poke "tag" (encode string (reflectSymbol proxy)) obj
+            case eacodec of
+              Left _ → pure obj
+              Right codec → FOST.poke "value" (encode codec v') obj
+      )
+      (\v' → un Star enc v' $> v)
+      v
 
   coerceR ∷ Variant r → Variant r'
   coerceR = unsafeCoerce
@@ -129,7 +130,7 @@ variantCase proxy eacodec (GCodec dec enc) = GCodec dec' enc'
 -- | The class used to enable the building of `Variant` codecs from a record of
 -- | codecs.
 class VariantCodec (rl ∷ RL.RowList Type) (ri ∷ Row Type) (ro ∷ Row Type) | rl → ri ro where
-  variantCodec ∷ forall proxy. proxy rl → Record ri → JsonCodec (Variant ro)
+  variantCodec ∷ ∀ proxy. proxy rl → Record ri → JsonCodec (Variant ro)
 
 instance variantCodecNil ∷ VariantCodec RL.Nil () () where
   variantCodec _ _ = variant
@@ -140,7 +141,8 @@ instance variantCodecCons ∷
   , R.Cons sym a ro' ro
   , IsSymbol sym
   , TE.TypeEquals co (Either a (JsonCodec a))
-  ) ⇒ VariantCodec (RL.Cons sym co rs) ri ro where
+  ) ⇒
+  VariantCodec (RL.Cons sym co rs) ri ro where
   variantCodec _ codecs =
     variantCase (Proxy ∷ Proxy sym) codec tail
     where

--- a/test/Test/Common.purs
+++ b/test/Test/Common.purs
@@ -12,9 +12,9 @@ import Effect.Console (log)
 import Foreign.Object.Gen (genForeignObject)
 import Test.QuickCheck (Result, quickCheck)
 import Test.QuickCheck.Gen (Gen)
-import Test.Util (propCodec, genInt)
+import Test.Util (genInt, propCodec)
 
-main :: Effect Unit
+main ∷ Effect Unit
 main = do
   log "Checking Maybe codec"
   quickCheck propMaybeCodec

--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -12,7 +12,7 @@ import Test.Prim as TestPrim
 import Test.Record as Record
 import Test.Variant as Variant
 
-main :: Effect Unit
+main ∷ Effect Unit
 main = do
   log "Checking Prim codecs"
   log "------------------------------------------------------------"

--- a/test/Test/Migration.purs
+++ b/test/Test/Migration.purs
@@ -19,7 +19,7 @@ import Test.QuickCheck (Result(..), quickCheck, (===))
 import Test.QuickCheck.Gen (Gen)
 import Test.Util (genJObject, propCodec'')
 
-main :: Effect Unit
+main ∷ Effect Unit
 main = do
   log "Checking addDefaultField adds a field if it is missing"
   quickCheck propDefaultFieldAdded
@@ -109,14 +109,14 @@ propNestForTaggedIdempotent ∷ Gen Result
 propNestForTaggedIdempotent = do
   propCodec'' J.stringify genTagged JAM.nestForTagged
   where
-    genTagged = do
-      tag ← genAsciiString
-      expectedValue ← GenJ.genJson
-      pure $ J.fromObject $
-        FO.fromFoldable
-          [ Tuple "tag" (J.fromString tag)
-          , Tuple "value" expectedValue
-          ]
+  genTagged = do
+    tag ← genAsciiString
+    expectedValue ← GenJ.genJson
+    pure $ J.fromObject $
+      FO.fromFoldable
+        [ Tuple "tag" (J.fromString tag)
+        , Tuple "value" expectedValue
+        ]
 
 testMigrationCodec
   ∷ { key ∷ String

--- a/test/Test/Prim.purs
+++ b/test/Test/Prim.purs
@@ -23,7 +23,7 @@ import Test.QuickCheck.Gen (Gen)
 import Test.Util (genInt, propCodec, propCodec', propCodec'')
 import Type.Proxy (Proxy(..))
 
-main :: Effect Unit
+main ∷ Effect Unit
 main = do
   log "Checking JNull codec"
   quickCheck propNull
@@ -117,13 +117,15 @@ newtype FixTest = FixTest (Maybe FixTest)
 
 derive instance newtypeFixTest ∷ Newtype FixTest _
 derive instance genericFixTest ∷ Generic FixTest _
-instance eqFixTest ∷ Eq FixTest where eq (FixTest x) (FixTest y) = x == y
-instance showFixTest ∷ Show FixTest where show x = genericShow x
+instance eqFixTest ∷ Eq FixTest where
+  eq (FixTest x) (FixTest y) = x == y
+
+instance showFixTest ∷ Show FixTest where
+  show x = genericShow x
 
 genFixTest ∷ Gen FixTest
 genFixTest = Gen.sized \n →
-  if n <= 1
-  then pure $ FixTest Nothing
+  if n <= 1 then pure $ FixTest Nothing
   else FixTest <$> Gen.resize (_ - 1) (GenC.genMaybe genFixTest)
 
 codecFixTest ∷ JA.JsonCodec FixTest

--- a/test/Test/Record.purs
+++ b/test/Test/Record.purs
@@ -38,8 +38,8 @@ instance showOuter ∷ Show Outer where
 instance eqOuter ∷ Eq Outer where
   eq (Outer o1) (Outer o2) =
     o1.a == o2.a
-    && o1.b == o2.b
-    && case o1.c, o2.c of
+      && o1.b == o2.b
+      && case o1.c, o2.c of
         Nothing, Nothing → true
         Just i1, Just i2 → i1.n == i2.n && i1.m == i2.m
         _, _ → false

--- a/test/Test/Variant.purs
+++ b/test/Test/Variant.purs
@@ -24,7 +24,7 @@ type TestVariant = V.Variant
   , c ∷ Maybe Boolean
   )
 
-main :: Effect Unit
+main ∷ Effect Unit
 main = do
   log "Checking Maybe-variant codec"
   quickCheck $
@@ -50,9 +50,10 @@ main = do
 codecMaybe ∷ ∀ a. JA.JsonCodec a → JA.JsonCodec (Maybe a)
 codecMaybe codecA =
   dimap toVariant fromVariant
-    (JAV.variant
-      # JAV.variantCase _Just (Right codecA)
-      # JAV.variantCase _Nothing (Left unit))
+    ( JAV.variant
+        # JAV.variantCase _Just (Right codecA)
+        # JAV.variantCase _Nothing (Left unit)
+    )
   where
   toVariant = case _ of
     Just a → V.inj _Just a
@@ -66,10 +67,11 @@ codecMaybe codecA =
 codecMaybeMatch ∷ ∀ a. JA.JsonCodec a → JA.JsonCodec (Maybe a)
 codecMaybeMatch codecA =
   dimap toVariant fromVariant
-    (JAV.variantMatch
-      { just: Right codecA
-      , nothing: Left unit
-      })
+    ( JAV.variantMatch
+        { just: Right codecA
+        , nothing: Left unit
+        }
+    )
   where
   toVariant = case _ of
     Just a → V.inj (Proxy ∷ _ "just") a
@@ -82,9 +84,10 @@ codecMaybeMatch codecA =
 codecEither ∷ ∀ a b. JA.JsonCodec a → JA.JsonCodec b → JA.JsonCodec (Either a b)
 codecEither codecA codecB =
   dimap toVariant fromVariant
-    (JAV.variant
-      # JAV.variantCase _Left (Right codecA)
-      # JAV.variantCase _Right (Right codecB))
+    ( JAV.variant
+        # JAV.variantCase _Left (Right codecA)
+        # JAV.variantCase _Right (Right codecB)
+    )
   where
   toVariant = case _ of
     Left a → V.inj _Left a


### PR DESCRIPTION
This adds the `purs-tidy` formatter, with unicode symbols and IDE import sorting. I've noticed that when working on another PR I keep deleting trailing spaces and otherwise creating a messy diff, and this would help me (and other contributors) produce easy-to-review diffs.