### PR TITLE
Fix Typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ codec =
 
 ### "Prismatic" codecs
 
-If you have a type with a pair of functions like the `preview` and `view` that make up a prism (`preview :: a -> Maybe b`, `view :: b -> a`), you can use these to adapt an existing codec to further refine it.
+If you have a type with a pair of functions like the `preview` and `review` that make up a prism (`preview :: a -> Maybe b`, `review :: b -> a`), you can use these to adapt an existing codec to further refine it.
 
 For example, to adapt the [`CA.string`](https://pursuit.purescript.org/packages/purescript-codec-argonaut/docs/Data.Codec.Argonaut#v:string) codec to only work for `NonEmptyString`s:
 

--- a/src/Data/Codec/Argonaut.purs
+++ b/src/Data/Codec/Argonaut.purs
@@ -397,7 +397,7 @@ coercible name codec =
 -- | be raised for JSON input.
 -- |
 -- | This function is named as such as the pair of functions it accepts
--- | correspond with the `preview` and `view` functions of a `Prism`-style lens.
+-- | correspond with the `preview` and `review` functions of a `Prism`-style lens.
 -- |
 -- | An example of this would be a codec for `Data.String.NonEmpty.NonEmptyString`:
 -- |


### PR DESCRIPTION
fix both readme documentation and in-code documentation, both use the term [`view`](https://pursuit.purescript.org/packages/purescript-profunctor-lenses/8.0.0/docs/Data.Lens.Getter#v:view) instead of [`review`](https://pursuit.purescript.org/packages/purescript-profunctor-lenses/8.0.0/docs/Data.Lens.Prism#v:review)