### PR TITLE
Error improvements

### DIFF
--- a/src/Data/Codec/Argonaut/Sum.purs
+++ b/src/Data/Codec/Argonaut/Sum.purs
@@ -319,7 +319,7 @@ parseNoFields encoding json expectedTag =
     EncodeNested {} → do
       obj ← lmap JErr $ CA.decode jobject json
       val ←
-        ( Obj.lookup expectedTag obj # note (JErr $ TypeMismatch ("Expecting a property `" <> expectedTag <> "`"))
+        ( Obj.lookup expectedTag obj # note NoCase
         ) ∷ _ Json
       fields ← lmap JErr $ CA.decode CA.jarray val ∷ _ (Array Json)
       when (fields /= [])
@@ -346,7 +346,7 @@ parseSingleField encoding json expectedTag = case encoding of
   EncodeNested { unwrapSingleArguments } → do
     obj ← lmap JErr $ CA.decode jobject json
     val ←
-      ( Obj.lookup expectedTag obj # note (JErr $ TypeMismatch ("Expecting a property `" <> expectedTag <> "`"))
+      ( Obj.lookup expectedTag obj # note NoCase
       ) ∷ _ Json
     if unwrapSingleArguments then
       pure val
@@ -472,8 +472,7 @@ instance gFlatCasesConstructorNoArg ∷
     let actualTag = Record.get (Proxy @tag) r ∷ String
 
     when (actualTag /= name)
-      $ Left
-          (JErr $ TypeMismatch ("Expecting tag `" <> name <> "`, got `" <> actualTag <> "`"))
+      $ Left NoCase
 
     pure (Constructor NoArguments)
 
@@ -507,8 +506,7 @@ instance gFlatCasesConstructorSingleArg ∷
 
     let actualTag = Record.get (Proxy @tag) r ∷ String
     when (actualTag /= name)
-      $ Left
-          (JErr $ TypeMismatch ("Expecting tag `" <> name <> "`, got `" <> actualTag <> "`"))
+      $ Left NoCase
 
     let r' = Record.delete (Proxy @tag) r ∷ Record rf
     pure (Constructor (Argument r'))

--- a/src/Data/Codec/Argonaut/Sum.purs
+++ b/src/Data/Codec/Argonaut/Sum.purs
@@ -1,29 +1,29 @@
 module Data.Codec.Argonaut.Sum
-  -- ( Encoding(..)
-  -- , FlatEncoding
-  -- , class GCases
-  -- , class GFields
-  -- , class GFlatCases
-  -- , defaultEncoding
-  -- , defaultFlatEncoding
-  -- , enumSum
-  -- , gCasesDecode
-  -- , gCasesEncode
-  -- , gFieldsDecode
-  -- , gFieldsEncode
-  -- , gFlatCasesDecode
-  -- , gFlatCasesEncode
-  -- , sum
-  -- , sumFlat
-  -- , sumFlatWith
-  -- , sumWith
-  -- , taggedSum
-  -- )
+  ( Encoding(..)
+  , FlatEncoding
+  , Err
+  , class GCases
+  , class GFields
+  , class GFlatCases
+  , defaultEncoding
+  , defaultFlatEncoding
+  , enumSum
+  , gCasesDecode
+  , gCasesEncode
+  , gFieldsDecode
+  , gFieldsEncode
+  , gFlatCasesDecode
+  , gFlatCasesEncode
+  , sum
+  , sumFlat
+  , sumFlatWith
+  , sumWith
+  , taggedSum
+  )
   where
 
 import Prelude
 
-import Control.Alt ((<|>))
 import Data.Argonaut.Core (Json)
 import Data.Argonaut.Core (Json, fromString) as J
 import Data.Array (catMaybes)
@@ -36,7 +36,6 @@ import Data.Codec.Argonaut as CA
 import Data.Codec.Argonaut.Record as CAR
 import Data.Either (Either(..), note)
 import Data.Generic.Rep (class Generic, Argument(..), Constructor(..), NoArguments(..), Product(..), Sum(..), from, to)
-import Data.Int (Parity)
 import Data.Maybe (Maybe(..), maybe)
 import Data.Profunctor (dimap)
 import Data.Symbol (class IsSymbol, reflectSymbol)
@@ -144,7 +143,7 @@ finalizeError name err =
   Named name $
     case err of
       NoCase → TypeMismatch "No case matched"
-      JErr err → err
+      JErr jerr → jerr
 
 data Err = NoCase | JErr JsonDecodeError
 

--- a/src/Data/Codec/Argonaut/Sum.purs
+++ b/src/Data/Codec/Argonaut/Sum.purs
@@ -141,10 +141,10 @@ finalizeError ∷ String → Err → JsonDecodeError
 finalizeError name err =
   Named name $
     case err of
-      NoCase → TypeMismatch "No case matched"
+      UnmatchedCase → TypeMismatch "No case matched"
       JErr jerr → jerr
 
-data Err = NoCase | JErr JsonDecodeError
+data Err = UnmatchedCase | JErr JsonDecodeError
 
 --------------------------------------------------------------------------------
 
@@ -251,7 +251,7 @@ instance gCasesSum ∷
       lhs _ = gCasesDecode encoding r1 tagged ∷ _ (Constructor name lhs)
       rhs _ = gCasesDecode encoding r2 tagged ∷ _ rhs
     case lhs unit of
-      Left NoCase → Inr <$> (rhs unit)
+      Left UnmatchedCase → Inr <$> (rhs unit)
       Left (JErr err) → Left (JErr err)
       Right val → Right (Inl val)
 
@@ -309,7 +309,7 @@ checkTag tagKey obj expectedTag = do
     ) ∷ _ Json
   tag ← CA.decode CA.string val # lmap JErr ∷ _ String
   when (tag /= expectedTag)
-    (Left NoCase)
+    (Left UnmatchedCase)
 
 parseNoFields ∷ Encoding → Json → String → Either Err Unit
 parseNoFields encoding json expectedTag =
@@ -317,7 +317,7 @@ parseNoFields encoding json expectedTag =
     EncodeNested {} → do
       obj ← lmap JErr $ CA.decode jobject json
       val ←
-        ( Obj.lookup expectedTag obj # note NoCase
+        ( Obj.lookup expectedTag obj # note UnmatchedCase
         ) ∷ _ Json
       fields ← lmap JErr $ CA.decode CA.jarray val ∷ _ (Array Json)
       when (fields /= [])
@@ -344,7 +344,7 @@ parseSingleField encoding json expectedTag = case encoding of
   EncodeNested { unwrapSingleArguments } → do
     obj ← lmap JErr $ CA.decode jobject json
     val ←
-      ( Obj.lookup expectedTag obj # note NoCase
+      ( Obj.lookup expectedTag obj # note UnmatchedCase
       ) ∷ _ Json
     if unwrapSingleArguments then
       pure val
@@ -375,7 +375,7 @@ parseManyFields encoding json expectedTag =
     EncodeNested {} → do
       obj ← lmap JErr $ CA.decode jobject json
       val ←
-        ( Obj.lookup expectedTag obj # note NoCase
+        ( Obj.lookup expectedTag obj # note UnmatchedCase
         ) ∷ _ Json
       lmap JErr $ CA.decode CA.jarray val
 
@@ -537,7 +537,7 @@ instance gFlatCasesSum ∷
       lhs _ = gFlatCasesDecode @tag r1 tagged ∷ _ (Constructor name lhs)
       rhs _ = gFlatCasesDecode @tag r2 tagged ∷ _ rhs
     case lhs unit of
-      Left NoCase → Inr <$> rhs unit
+      Left UnmatchedCase → Inr <$> rhs unit
       Left (JErr err) → Left (JErr err)
       Right val → Right (Inl val)
 

--- a/test/Test/Sum.purs
+++ b/test/Test/Sum.purs
@@ -3,7 +3,7 @@ module Test.Sum where
 import Prelude
 
 import Control.Monad.Error.Class (liftEither)
-import Data.Argonaut.Core (stringifyWithIndent)
+import Data.Argonaut.Core (stringify, stringifyWithIndent)
 import Data.Argonaut.Decode (parseJson)
 import Data.Bifunctor (lmap)
 import Data.Codec (decode, encode)
@@ -87,14 +87,14 @@ check ∷ ∀ a. Show a ⇒ Eq a ⇒ JsonCodec a → a → String → Effect Uni
 check codec val expectEncoded = do
   let encodedStr = stringifyWithIndent 2 $ encode codec val
   when (encodedStr /= expectEncoded) $
-    throw ("check failed, expected: " <> expectEncoded <> ", got: " <> encodedStr)
+    throw ("encode check failed, expected: " <> expectEncoded <> ", got: " <> encodedStr)
 
   json ← liftEither $ lmap (show >>> error) $ parseJson encodedStr
 
-  decoded ← liftEither $ lmap (show >>> error) $ decode codec json
+  decoded ← liftEither $ lmap (\err -> error ("decode failed: " <> show err <> " JSON was: " <> stringify json)) $ decode codec json
 
   when (decoded /= val) $
-    throw ("check failed, expected: " <> show val <> ", got: " <> show decoded)
+    throw ("decode check failed, expected: " <> show val <> ", got: " <> show decoded)
 
 main ∷ Effect Unit
 main = do


### PR DESCRIPTION
This is an alternative solution for PR #68 . It solves issue #66 .

The main idea is: The existing type `Either JsonDecodeError a` for decoders is extended by wrapping it into a custom Error:

```
data Err = UnmatchedCase | JErr JsonDecodeError
```

In this way an unmatched Case is treated as an error. In my view this makes the code a bit simpler, because we profit from short circuiting.

@wclr @garyb 
Im curious about your opinions.

Test cases are added, too.