### PR TITLE
`optionalWith`: A generalized `optional` modifier.

### DIFF
--- a/src/Data/Codec/Argonaut.purs
+++ b/src/Data/Codec/Argonaut.purs
@@ -322,7 +322,7 @@ recordPropOptionalWith
   ⇒ Row.Lacks p r
   ⇒ Proxy p
   → (Maybe a → b)
-  → (b → a)
+  → (b → Maybe a)
   → JsonCodec a
   → JPropCodec (Record r)
   → JPropCodec (Record r')
@@ -350,7 +350,9 @@ recordPropOptionalWith p normalize denormalize codecA codecR = Codec.codec dec' 
       b ∷ b
       b = Record.get p val
 
-    Tuple key (Codec.encode codecA $ denormalize b) : w
+    case denormalize b of
+      Just a → Tuple key (Codec.encode codecA a) : w
+      Nothing → w
 
   unsafeForget ∷ Record r' → Record r
   unsafeForget = unsafeCoerce

--- a/src/Data/Codec/Argonaut/Record.purs
+++ b/src/Data/Codec/Argonaut/Record.purs
@@ -54,7 +54,7 @@ newtype Optional a = Optional (CA.JsonCodec a)
 -- | property is not present in the JSON object.
 newtype OptionalWith a b = OptionalWith
   { normalize ∷ Maybe a → b
-  , denormalize ∷ b → a
+  , denormalize ∷ b → Maybe a
   , codec ∷ CA.JsonCodec a
   }
 
@@ -63,7 +63,7 @@ optional ∷ ∀ a. CA.JsonCodec a → Optional a
 optional = Optional
 
 -- | A lowercase alias for `OptionalWith`, provided for stylistic reasons only.
-optionalWith ∷ ∀ a b. (Maybe a → b) → (b → a) → CA.JsonCodec a → OptionalWith a b
+optionalWith ∷ ∀ a b. (Maybe a → b) → (b → Maybe a) → CA.JsonCodec a → OptionalWith a b
 optionalWith normalize denormalize codec = OptionalWith { normalize, denormalize, codec }
 
 -- | The class used to enable the building of `Record` codecs by providing a
@@ -103,7 +103,7 @@ else instance rowListCodecConsOptionalWith ∷
     CA.recordPropOptionalWith (Proxy ∷ Proxy sym) ret.normalize ret.denormalize ret.codec tail
 
     where
-    ret ∷ { normalize ∷ Maybe a → b, denormalize ∷ b → a, codec ∷ CA.JsonCodec a }
+    ret ∷ { normalize ∷ Maybe a → b, denormalize ∷ b → Maybe a, codec ∷ CA.JsonCodec a }
     ret = coerce (Rec.get (Proxy ∷ Proxy sym) codecs ∷ OptionalWith a b)
 
     tail ∷ CA.JPropCodec (Record ro')


### PR DESCRIPTION
## Current state of optional field parsing with `optional`

Let’s say we have a record with an optional `flag` field:

```purescript
type Sample = { flag ∷ Maybe Boolean }
```

The appropiate codec for this would look like:

```purescript
codecSample ∷ JsonCodec Sample
codecSample =
  CAR.object "Sample"
    { flag: CAR.optional CA.boolean
    }
```

This setup is convenient, as it supports multiple JSON inputs:

- `{}` is parsed as `{ flag: Nothing }`
- `{ "flag": true }` is parsed as `{ flag: Just true }`
- `{ "flag": false }` is parsed as `{ flag: Just false }`

---

## Introducing `optionalWith`

However, in many use cases, working with a `Maybe Boolean` isn’t ideal. Often, we’d prefer to use a plain `Boolean`, treating both `Nothing` and `Just false` as false:

```purescript
type Sample2 = { flag ∷ Boolean }
```

With the current version of `codec-argonaut`, we’d need to define both `Sample` and `Sample2`, along with conversion functions between them.

To avoid this, the PR introduces a new modifier: `optionalWith`, a more flexible version of `optional`.

```purescript
optionalWith ∷ ∀ a b. (Maybe a → b) → (b → Maybe a) → CA.JsonCodec a → OptionalWith a b
```

Here’s how it can be used:

```purescript
codecSample2 ∷ JsonCodec Sample2
codecSample2 =
  CAR.object "Sample2"
    { flag: CAR.optionalWith
        (fromMaybe false)
        (if _ then Just true else Nothing)
        CA.boolean
    }
```

This codec handles the following cases directly:

- `{}` is decoded as `{ flag: false }`
- `{ "flag": true }` is decoded as `{ flag: true }`
- `{ "flag": false }` is decoded as `{ flag: false }`

---

## Other Usecases

This pattern is especially useful when working with JavaScript APIs, where fields are often omitted instead of explicitly set to a default or “empty” value.

Other examples where `optionalWith` is useful include:

- Omitting empty foreign objects or arrays
- Flattening `Maybe (Maybe a)` to just `Maybe a`, useful for fields that can be either null or missing

__Bonus:__
`optionalWith` is a generalization of `optional`, which can now internally be redefined as:

```purescript
optional = optionalWith identity identity
```

As a result, this MR introduces no code duplication. Tests are added that verify the behavior.